### PR TITLE
Set fixed versions on setup.py to avoid breaking changes for new versions of Data Catalog library.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open('HISTORY.md') as history_file:
 
 setuptools.setup(
     name='datacatalog-util',
-    version='0.11.4',
+    version='0.11.5',
     author='Marcelo Miranda',
     author_email='mesmacosta@gmail.com',
     description='A package to manage Google Cloud Data Catalog'

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setuptools.setup(
     include_package_data=True,
     install_requires=(
         'google-cloud-datacatalog >= 1.0.0, < 2.0.0',
-        'datacatalog-tag-manager',
+        'datacatalog-tag-manager==2.0.5',
         'datacatalog-tag-exporter',
         'datacatalog-fileset-enricher',
         'datacatalog-fileset-processor==0.1.4',

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ setuptools.setup(
     },
     include_package_data=True,
     install_requires=(
+        'google-cloud-datacatalog >= 1.0.0, < 2.0.0',
         'datacatalog-tag-manager',
         'datacatalog-tag-exporter',
         'datacatalog-fileset-enricher',


### PR DESCRIPTION
<!--
Customized from the template (https://github.com/docker/cli/blob/master/.github/PULL_REQUEST_TEMPLATE.md)

Please make sure you've read and understood our contributing guidelines;
https://github.com/GoogleCloudPlatform/datacatalog-connectors-rdbms/blob/master/docs/contributing.md

Please provide the following information:
-->

**- What I did**
Set fixed versions on setup.py to avoid breaking changes for new versions of Data Catalog library.

**- How I did it**
--

**- How to verify it**
Install from PyPI and run datacatalog-util

**- Description for the changelog**
Set fixed versions on setup.py to avoid breaking changes for new versions of Data Catalog library.
